### PR TITLE
don't try to dispatch to UNIVERSAL::import

### DIFF
--- a/lib/MooX/PluginRoles.pm
+++ b/lib/MooX/PluginRoles.pm
@@ -43,6 +43,8 @@ sub import {
 
     {
         my $old_import = $base_class->can('import');
+        undef $old_import
+            if defined &UNIVERSAL::import && $old_import == \&UNIVERSAL::import;
 
         no strict 'refs';          ## no critic (ProhibitNoStrict)
         no warnings 'redefine';    ## no critic (ProhibitNoWarnings)


### PR DESCRIPTION
When installing an import, we try to wrap an existing method if it exists. This may not be a very reasonable thing to do. All of the original arguments are passed along, including the ones handled by this module, so the parent probably won't handle them correctly.

Future versions of perl are intending to have a real UNIVERSAL::import method, rather than a magical special case. And this method will throw errors if passed arguments, since it means they were not handled. This conflicts with the behavior of this module, which passes along the import arguments.

We can detect if the existing import method is UNIVERSAL::import, and avoid calling it.